### PR TITLE
Fixed mock_objects UserWarning

### DIFF
--- a/tests/mock_objects/mock_objects.py
+++ b/tests/mock_objects/mock_objects.py
@@ -3,13 +3,14 @@ from bs4 import BeautifulSoup
 import pathlib
 import os
 
+
 def get_mock_config() -> ConfigParser:
     config = ConfigParser()
     config['Features'] = {}
     config['HTML_Features'] = {}
     config['URL_Features'] = {}
     config['URL_Features']['url_token_delimiter'] = '.'
-    config['Network_Features']={}
+    config['Network_Features'] = {}
     config['Javascript_Features'] = {}
     config['Classifiers'] = {}
     config['Imbalanced Datasets'] = {}
@@ -24,10 +25,11 @@ def get_mock_config() -> ConfigParser:
     config["Summary"] = {}
     return config
 
+
 def get_soup(filename) -> BeautifulSoup:
     print('GETTING SOUP')
     current_file_folder = pathlib.Path(__file__).parent.absolute()
-    test_file = os.path.join(current_file_folder,'mock_webpages', filename)
+    test_file = os.path.join(current_file_folder, 'mock_webpages', filename)
     with open(test_file) as f:
-        soup = BeautifulSoup(f.read())
+        soup = BeautifulSoup(f.read(), features="lxml")
     return soup


### PR DESCRIPTION
```
No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
```